### PR TITLE
Update lolmer_bigreactor_monitor_prog.lua

### DIFF
--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -264,16 +264,16 @@ end
 
 local function termRestore()
   local ccVersion = nil
-  ccVersion = os.version()
-
-	if ccVersion == "CraftOS 1.6" then
-		term.native()
-	elseif ccVersion == "CraftOS 1.5" then
-		term.restore()
-	else -- Default to older term.restore
-		printLog("Unsupported CraftOS found. Reported version is \""..ccVersion.."\".")
-		term.restore()
-	end -- if ccVersion
+  ccVersion = os.version() 
+        
+        if ccVersion == "CraftOS 1.6" or "CraftOS 1.7" then
+                term.native()
+        elseif ccVersion == "CraftOS 1.5" then
+                term.restore()
+        else -- Default to older term.restore
+                printLog("Unsupported CraftOS found. Reported version is "\"..ccVersion.."\".")
+                term.restore()
+        end -- if ccVersion
 end -- function termRestore()
 
 local function printLog(printStr)


### PR DESCRIPTION
Added CraftOS 1.7 to local function termRestore(); fixed syntax on line 273
https://github.com/sandalle/minecraft_bigreactor_control/issues/48