### PR TITLE
Stop overzealous controlRodAdjustAmount adjustment amount adjustment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ scatmanjohn_bigreactor_monitor_prog.lua
 scatmanjohn_bigreactor_startup.lua
 sg_control.lua
 sg_startup.lua
+*.swp

--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -992,11 +992,10 @@ local function temperatureControl(reactorIndex)
 							--we're not climbing by leaps and bounds, let's give it a rod adjustment based on temperature increase
 							local diffAmount = reactorTemp - lastTempPoll
 							diffAmount = (round(diffAmount/10, 0))/5
-							controlRodAdjustAmount = diffAmount
-							if (rodPercentage + controlRodAdjustAmount) > 99 then
+							if (rodPercentage + diffAmount) > 99 then
 								reactor.setAllControlRodLevels(99)
 							else
-								reactor.setAllControlRodLevels(rodPercentage + controlRodAdjustAmount)
+								reactor.setAllControlRodLevels(rodPercentage + diffAmount)
 							end
 						end --if ((reactorTemp - lastTempPoll) > 100) then
 					elseif ((lastTempPoll - reactorTemp) < (reactorTemp * 0.005)) then
@@ -1028,11 +1027,10 @@ local function temperatureControl(reactorIndex)
 							--we're not descending quickly, let's bump it based on descent rate
 							local diffAmount = lastTempPoll - reactorTemp
 							diffAmount = (round(diffAmount/10, 0))/5
-							controlRodAdjustAmount = diffAmount
-							if (rodPercentage - controlRodAdjustAmount) < 0 then
+							if (rodPercentage - diffAmount) < 0 then
 								reactor.setAllControlRodLevels(0)
 							else
-								reactor.setAllControlRodLevels(rodPercentage - controlRodAdjustAmount)
+								reactor.setAllControlRodLevels(rodPercentage - diffAmount)
 							end
 						end --if ((lastTempPoll - reactorTemp) > 100) then
 					elseif (reactorTemp == lastTempPoll) then

--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -1906,6 +1906,7 @@ function main()
 		local reactor = nil
 		local monitorIndex = 1
 		local sd = 0
+		local activeReactorCount = 0
 
 		-- For multiple reactors/monitors, monitor #1 is reserved for overall status
 		-- or for multiple reactors/turbines and only one monitor

--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -1906,7 +1906,6 @@ function main()
 		local reactor = nil
 		local monitorIndex = 1
 		local sd = 0
-		local activeReactorCount = 0
 
 		-- For multiple reactors/monitors, monitor #1 is reserved for overall status
 		-- or for multiple reactors/turbines and only one monitor


### PR DESCRIPTION
The amount of the words "adjustment" and "amount" in the title needs to be adjusted.

Nevertheless, from the commit message:
> It makes one reactor mess with the others. I guess it makes sense for
one reactor setups to carry over between cycles, but as soon as there's
more, you're in for surprises. More so since that variable is also used
for the manual adjustment amount.

Figured that out while I was testing the new UI handlers from thetaphi@669e07972a38dcdc2b4a7f0ad6cadd1a89bd02da