### PR TITLE
Improved Monitor Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ scatmanjohn_bigreactor_monitor_prog.lua
 scatmanjohn_bigreactor_startup.lua
 sg_control.lua
 sg_startup.lua
+*.swp

--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -1906,6 +1906,7 @@ function main()
 		local reactor = nil
 		local monitorIndex = 1
 		local sd = 0
+		local activeReactorCount = 0
 
 		-- For multiple reactors/monitors, monitor #1 is reserved for overall status
 		-- or for multiple reactors/turbines and only one monitor

--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -1,6 +1,6 @@
 --[[
 Program name: Lolmer's EZ-NUKE reactor control system
-Version: v0.3.17
+Version: v0.3.17-ta
 Programmer: Lolmer
 Great assistance by Mechaet
 Last update: 2015-04-01
@@ -43,7 +43,9 @@ Features:
 	A new cruise mode from mechaet, ONLINE will be "blue" when active, to keep your actively cooled reactors running smoothly.
 
 GUI Usage:
-	The "<" and ">" buttons, when right-clicked with the mouse, will decrease and increase, respectively, the values assigned to the monitor:
+	The second line of a monitor "< ---------------- >" lets you control what the monitor displays. Clicking "<" and ">" switches between machines of the same type,
+	while clicking between them switches between Reactors, Turbines and Status.
+	The other "<" and ">" buttons, when right-clicked with the mouse, will decrease and increase, respectively, the values assigned to the monitor:
 		"Rod (%)" will lower/raise the Reactor Control Rods for that Reactor
 		"mB/t" will lower/raise the Turbine Flow Rate maximum for that Turbine
 		"RPM" will lower/raise the target Turbine RPM for that Turbine
@@ -112,7 +114,7 @@ TODO:
 
 
 -- Some global variables
-local progVer = "0.3.17"
+local progVer = "0.3.17-ta"
 local progName = "EZ-NUKE"
 local sideClick, xClick, yClick = nil, 0, 0
 local loopTime = 2

--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -1906,7 +1906,6 @@ function main()
 		local reactor = nil
 		local monitorIndex = 1
 		local sd = 0
-		local activeReactorCount = 0
 
 		-- For multiple reactors/monitors, monitor #1 is reserved for overall status
 		-- or for multiple reactors/turbines and only one monitor

--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -3,7 +3,7 @@ Program name: Lolmer's EZ-NUKE reactor control system
 Version: v0.3.17
 Programmer: Lolmer
 Great assistance by Mechaet
-Last update: 2015-03-29
+Last update: 2015-04-01
 Pastebin: http://pastebin.com/fguScPBQ
 GitHub: https://github.com/sandalle/minecraft_bigreactor_control
 

--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -233,6 +233,7 @@ config.load = function(path)
 	assert(path ~= nil, "Path can't be nil")
 	local f = fs.open(path, "r")
 	if f ~= nil then
+		printLog("Successfully opened "..path.." for reading EOL")
 		local tab = {}
 		local line = ""
 		local newLine
@@ -281,6 +282,7 @@ config.load = function(path)
 		
 		return tab
 	else
+		printLog("Could NOT opened "..path.." for reading! EOL")
 		return nil
 	end
 end --config.load = function(path)

--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -156,7 +156,7 @@ local function termRestore()
 	ccVersion = os.version()
 
 	if ccVersion == "CraftOS 1.6" or "CraftOS 1.7" then
-		term.native()
+		term.redirect(term.native())
 	elseif ccVersion == "CraftOS 1.5" then
 		term.restore()
 	else -- Default to older term.restore

--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -96,7 +96,7 @@ ChangeLog:
 	- Set monitor scale before checking size fixing Issue #50.
 	- Having a monitor is now optional, closing Issue #46.
 	- Incorporate steam supply and demand in reactor control thanks to @thetaphi (Nicolas Kratz).
-	- Added turbine coil auto dis-/engage thanks to @thetaphi (Nicolas Kratz).
+	- Added turbine coil auto dis-/engage (Issue #51 and #55) thanks to @thetaphi (Nicolas Kratz).
 
 Prior ChangeLogs are posted at https://github.com/sandalle/minecraft_bigreactor_control/releases
 

--- a/lolmer_bigreactor_monitor_prog.lua
+++ b/lolmer_bigreactor_monitor_prog.lua
@@ -378,7 +378,7 @@ local function printCentered(printString, yPos, monitorIndex)
 	monitor = monitorList[monitorIndex]
 
 	if not monitor then
-		printLog("monitor["..monitorIndex.."] in printCentered() is NOT a valid monitor.")
+		printLog("monitor["..monitorIndex.."] in printCentered() is NOT a valid monitor.", ERROR)
 		return -- Invalid monitorIndex
 	end
 
@@ -413,7 +413,7 @@ local function printLeft(printString, yPos, monitorIndex)
 	monitor = monitorList[monitorIndex]
 
 	if not monitor then
-		printLog("monitor["..monitorIndex.."] in printLeft() is NOT a valid monitor.")
+		printLog("monitor["..monitorIndex.."] in printLeft() is NOT a valid monitor.", ERROR)
 		return -- Invalid monitorIndex
 	end
 
@@ -440,7 +440,7 @@ local function printRight(printString, yPos, monitorIndex)
 	monitor = monitorList[monitorIndex]
 
 	if not monitor then
-		printLog("monitor["..monitorIndex.."] in printRight() is NOT a valid monitor.")
+		printLog("monitor["..monitorIndex.."] in printRight() is NOT a valid monitor.", ERROR)
 		return -- Invalid monitorIndex
 	end
 
@@ -470,7 +470,7 @@ local function clearMonitor(printString, monitorIndex)
 	printLog("Called as clearMonitor(printString="..printString..",monitorIndex="..monitorIndex..").")
 
 	if not monitor then
-		printLog("monitor["..monitorIndex.."] in clearMonitor(printString="..printString..",monitorIndex="..monitorIndex..") is NOT a valid monitor.")
+		printLog("monitor["..monitorIndex.."] in clearMonitor(printString="..printString..",monitorIndex="..monitorIndex..") is NOT a valid monitor.", ERROR)
 		return -- Invalid monitorIndex
 	end
 
@@ -602,7 +602,7 @@ UI.handlePossibleClick = function(self)
 	if (yClick == 2) then
 		local monitorData = monitorAssignments[sideClick]
 		if monitorData == nil then
-			printLog("UI.handlePossibleClick(): "..sideClick.." is unassigned, can't handle click", ERROR)
+			printLog("UI.handlePossibleClick(): "..sideClick.." is unassigned, can't handle click", WARN)
 			return
 		end
 
@@ -1022,6 +1022,7 @@ local function assignMonitors()
 	monitorAssignments = {}
 
 	printLog("Assigning monitors...")
+	tprint(getfenv())
 
 	local m = config.load(monitorOptionFileName) 
 	if (m ~= nil) then
@@ -2207,15 +2208,18 @@ function main()
 			local monitorType =  deviceData.type
 			monitor = monitorList[monitorIndex]
 
-			printLog("main(): Trying to display "..monitorType.." on "..monitorNames[monitorIndex].."["..monitorIndex.."]")
+			printLog("main(): Trying to display "..monitorType.." on "..monitorNames[monitorIndex].."["..monitorIndex.."]", DEBUG)
 
 			if #monitorList < (#reactorList + #turbineList + 1) then
 				printLog("You may want "..(#reactorList + #turbineList + 1).." monitors for your "..#reactorList.." connected reactors and "..#turbineList.." connected turbines.")
 			end
 
-			if not monitor then
+			if (not monitor) or (not monitor.getSize()) then
 
-				printLog("monitor["..monitorIndex.."] in main() is NOT a valid monitor.")
+				printLog("monitor["..monitorIndex.."] in main() is NOT a valid monitor, discarding", ERROR)
+				monitorAssignments[monitorName] = nil
+				-- we need to get out of the for loop now, or it will dereference x.next (where x is the element we just killed) and crash
+				break
 
 			elseif monitorType == "Status" then
 
@@ -2232,7 +2236,7 @@ function main()
 
 					if deviceData.reactorName == reactorNames[reactorIndex] then
 
-						-- printLog("Attempting to display reactor["..reactorIndex.."] on monitor["..monitorIndex.."]...")
+						printLog("Attempting to display reactor["..reactorIndex.."] on monitor["..monitorIndex.."]...", DEBUG)
 						-- Only attempt to assign a monitor if we have a monitor for this reactor
 						if (reactorMonitorIndex <= #monitorList) then
 							printLog("Displaying reactor["..reactorIndex.."] on monitor["..reactorMonitorIndex.."].")
@@ -2258,7 +2262,7 @@ function main()
 				for turbineIndex = 1, #turbineList do
 
 					if deviceData.turbineName == turbineNames[turbineIndex] then
-						-- printLog("Attempting to display turbine["..turbineIndex.."] on monitor["..turbineMonitorIndex.."]...")
+						printLog("Attempting to display turbine["..turbineIndex.."] on monitor["..turbineMonitorIndex.."]...", DEBUG)
 						-- Only attempt to assign a monitor if we have a monitor for this turbine
 						if (turbineMonitorIndex <= #monitorList) then
 							printLog("Displaying turbine["..turbineIndex.."] on monitor["..turbineMonitorIndex.."].")


### PR DESCRIPTION
Changes:
* Monitors can be reconfigured via GUI. On the bottom line, right click the arrows to switch from Status -> Reactor 0 -> Reactor 1 -> Turbine 0 and so on. Right click between the arrows to switch Status -> first Reactor -> first Turbine -> Status. Configurations are saved across reboot.
* Monitors should not lose clicks any more. They also update when clicked, not only after the control cycle ran. 
* The computer automatically detects and configures new devices on the network.
* Keyboard commands on the computer itself, to aid troubleshooting. Press h for help.

I call that "feature complete". There might be bugs that I didn't find, or didn't have a chance to find, since I'm running CC 1.7, and only have a limited testing setup (Two reactors, two turbines, seven monitors). I'm working on the autobuilding of turbines, but I think the code is at a point where the input of others is more valuable than trying to think of everything myself.